### PR TITLE
fix(security): install-skills — name de skill não pode ser componente de caminho livre

### DIFF
--- a/src/install-skills.js
+++ b/src/install-skills.js
@@ -49,8 +49,13 @@ export function parseSkill(raw) {
       if (m) meta[m[1]] = m[2].trim();
     }
   }
+  // name vira componente de caminho nos writers (path.join(base, name)):
+  // um server comprometido publicando name com '../' escreveria arquivo com
+  // corpo controlado em diretório arbitrário da máquina do usuário. Só
+  // charset seguro passa; qualquer outra coisa cai no default.
+  const name = /^[\w-]+$/.test(meta.name || '') ? meta.name : 'zihin-skill';
   return {
-    name: meta.name || 'zihin-skill',
+    name,
     description: meta.description || '',
     body: (fm ? raw.slice(fm[0].length) : raw).replace(/^\n+/, ''),
   };

--- a/test/install-skills.test.js
+++ b/test/install-skills.test.js
@@ -42,6 +42,18 @@ test('parseSkill tolera arquivo sem frontmatter', () => {
   assert.match(s.body, /^# Só corpo/);
 });
 
+test('SEGURANÇA: parseSkill rejeita name com path traversal', () => {
+  // name vira path.join(base, name) nos writers — um server comprometido
+  // com name '../../../x' escreveria fora do diretório de skills.
+  for (const evil of ['../../../tmp/evil', '..', 'a/b', 'a\\b', '.hidden', 'nome com espaço']) {
+    const s = parseSkill(`---\nname: ${evil}\ndescription: d\n---\ncorpo`);
+    assert.equal(s.name, 'zihin-skill', `name malicioso "${evil}" deve cair no default`);
+  }
+  // charset legítimo passa intacto
+  assert.equal(parseSkill('---\nname: zihin-criar-agente\n---\nx').name, 'zihin-criar-agente');
+  assert.equal(parseSkill('---\nname: skill_v2\n---\nx').name, 'skill_v2');
+});
+
 test('toCursorRule gera .mdc com description e alwaysApply false', () => {
   const mdc = toCursorRule(parseSkill(SAMPLE));
   assert.match(mdc, /^---\ndescription: Playbook de teste/);


### PR DESCRIPTION
## O que é

Achado **pré-existente** (desde a v1.4.0) da revisão de segurança quádrupla de 02/08 sobre a pilha da #6 — como não pertence à migração, vem em PR próprio sobre a `main`, mergeável independente.

## O problema

`parseSkill` extraía `name` do frontmatter com valor livre e os 4 writers fazem `path.join(base, name)`. Um server comprometido publicando um resource `zihin://skills/*` com `name: ../../../algum/caminho` faria o `install-skills` gravar arquivo **com corpo 100% controlado** em diretório arbitrário da máquina do usuário (com `--global`, a partir de `~/.claude`).

## A correção

`parseSkill` vira o choke point: só `/^[\w-]+$/` passa; traversal, separadores, espaços e dotfiles caem no default `zihin-skill` — mesmo comportamento já usado para frontmatter ausente. Teste novo cobre 6 formas maliciosas e 2 legítimas.

## Prova

10/10 sem rede (`node --test test/install-skills.test.js`).

Nota: CI ficará vermelho até o secret `ZIHIN_API_KEY` do repo ser rotacionado (revogado — diagnóstico no #7).

https://claude.ai/code/session_01YBAuDzJzVLEBmfNebydhFD