### PR TITLE
feat(fase-0): erros por código, diff por conteúdo no keepalive, -32022 fatal

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ import {
   ResourceListChangedNotificationSchema,
   PromptListChangedNotificationSchema,
 } from '@modelcontextprotocol/sdk/types.js';
+import { writeSync } from 'node:fs';
 
 const VERSION = '1.4.0';
 const DEFAULT_MCP_URL = 'https://llm.zihin.ai/mcp';
@@ -279,14 +280,24 @@ export async function startProxy() {
 
   // --- Wrapper com retry para operações remotas ---
 
-  async function withRetry(operation) {
+  async function withRetry(operation, { reissue = true } = {}) {
     try {
       return await operation();
     } catch (error) {
       // Não retry em erro fatal: reemitir com a mesma key/versão falha igual
       if (isAuthError(error) || isProtocolVersionError(error)) throw error;
       if (isConnectionError(error)) {
-        log(`Erro de conexão detectado. Reconectando...`);
+        log('Erro de conexão detectado. Reconectando...');
+        if (!reissue) {
+          // tools/call NÃO é idempotente (ex.: chat_with_agent): em timeout ou
+          // conexão caída pós-envio o request pode ter executado no server, e
+          // reemitir duplicaria o efeito. Reconecta em background e devolve o
+          // erro ao host — quem decide reenviar é o usuário. (Decisão de
+          // revisão 02/08; a extensão Tasks da Fase 3 devolve a transparência
+          // do jeito certo.)
+          reconnect();
+          throw error;
+        }
         await reconnect();
         return await operation();
       }
@@ -336,7 +347,7 @@ export async function startProxy() {
   localServer.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
     try {
-      return await withRetry(() => remoteClient.callTool({ name, arguments: args }));
+      return await withRetry(() => remoteClient.callTool({ name, arguments: args }), { reissue: false });
     } catch (error) {
       return {
         content: [{ type: 'text', text: `Erro ao executar tool "${name}": ${error.message}` }],
@@ -462,6 +473,12 @@ export function isProtocolVersionError(error) {
 export function isConnectionError(error) {
   if (isAuthError(error) || isProtocolVersionError(error)) return false;
 
+  // Status HTTP transitórios de LB/CDN/tunnel/deploy (nginx 502, Cloudflare
+  // 503, gateway timeout 504, 404 de janela de deploy) são recuperáveis —
+  // substitui de forma principiada o antigo casamento da string '404'.
+  const status = httpStatus(error);
+  if (status === 404 || status === 408 || status === 502 || status === 503 || status === 504) return true;
+
   const code = error?.code ?? error?.cause?.code; // undici embrulha rede em 'fetch failed' com cause
   switch (code) {
     case 'ECONNREFUSED':
@@ -498,7 +515,15 @@ function sleep(ms) {
 
 /**
  * Log para stderr (stdout é reservado para JSON-RPC MCP).
+ *
+ * writeSync, não console.error: stderr para pipe é assíncrono em POSIX e
+ * process.exit() não drena o buffer — as mensagens de ERRO FATAL sumiriam
+ * exatamente quando mais importam (o host veria só "Server disconnected").
  */
 function log(message) {
-  console.error(message);
+  try {
+    writeSync(2, message + '\n');
+  } catch {
+    // stderr fechado — nada a fazer
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -69,10 +69,17 @@ export async function startProxy() {
 
   // Estado mutável — atualizado em cada (re)conexão
   let remoteTools = [];
+  let remoteToolsSignature = '[]'; // assinatura por conteúdo — ver keepalive
   let remoteResources = [];
   let remotePrompts = [];
   let reconnecting = false;
   let keepaliveTimer = null;
+
+  /** Atualiza o cache de tools mantendo a assinatura de conteúdo em sincronia. */
+  function setRemoteTools(tools) {
+    remoteTools = tools;
+    remoteToolsSignature = JSON.stringify(tools);
+  }
 
   const remoteClient = new Client(
     { name: 'zihin-mcp-proxy', version: VERSION },
@@ -115,7 +122,7 @@ export async function startProxy() {
       remoteClient.listPrompts(),
     ]);
 
-    remoteTools = toolsResult.status === 'fulfilled' ? toolsResult.value.tools : [];
+    setRemoteTools(toolsResult.status === 'fulfilled' ? toolsResult.value.tools : []);
     remoteResources = resourcesResult.status === 'fulfilled' ? resourcesResult.value.resources : [];
     remotePrompts = promptsResult.status === 'fulfilled' ? promptsResult.value.prompts : [];
 
@@ -129,7 +136,7 @@ export async function startProxy() {
       log('Notificação: tools atualizadas. Re-descobrindo...');
       try {
         const result = await remoteClient.listTools();
-        remoteTools = result.tools;
+        setRemoteTools(result.tools);
         log(`Tools atualizadas: ${remoteTools.length} tools`);
       } catch (error) {
         log(`Erro ao re-descobrir tools: ${error.message}`);
@@ -188,26 +195,42 @@ export async function startProxy() {
     }
   }
 
+  // --- Erros fatais (auth / versão de protocolo) ---
+
+  function failIfFatal(error) {
+    if (isAuthError(error)) {
+      log('');
+      log('ERRO FATAL: API Key inválida ou revogada.');
+      log('Atualize ZIHIN_API_KEY e reinicie o processo.');
+      process.exit(1);
+    }
+    if (isProtocolVersionError(error)) {
+      log('');
+      log('ERRO FATAL: o server não aceita mais a versão de protocolo MCP deste proxy (-32022).');
+      log('Atualize o pacote: npx @zihin/mcp-server@latest (ou npm install -g @zihin/mcp-server@latest).');
+      process.exit(1);
+    }
+  }
+
   // --- Smart keepalive (Fix 4) ---
 
   function startKeepalive() {
     stopKeepalive();
     keepaliveTimer = setInterval(async () => {
       try {
-        // Discovery contínuo: detecta tools novas/removidas + valida auth
+        // Discovery contínuo: detecta mudança nas tools + valida auth.
+        // Com o server stateless este é o ÚNICO detector de mudança — não há
+        // mais GET stream para entregar list_changed —, então o diff é por
+        // CONTEÚDO: comparar length não detecta troca de tool com contagem
+        // igual (ex.: deploy que renomeia uma tool).
         const result = await remoteClient.listTools();
-        const newCount = result.tools.length;
-        if (newCount !== remoteTools.length) {
-          log(`Keepalive: tools atualizadas (${remoteTools.length} → ${newCount})`);
-          remoteTools = result.tools;
+        const signature = JSON.stringify(result.tools);
+        if (signature !== remoteToolsSignature) {
+          log(`Keepalive: tools atualizadas (${remoteTools.length} → ${result.tools.length})`);
+          setRemoteTools(result.tools);
         }
       } catch (error) {
-        if (isAuthError(error)) {
-          log('');
-          log('ERRO FATAL: API Key inválida ou revogada.');
-          log('Atualize ZIHIN_API_KEY e reinicie o processo.');
-          process.exit(1);
-        }
+        failIfFatal(error);
         log('Keepalive falhou — reconectando...');
         reconnect();
       }
@@ -246,13 +269,8 @@ export async function startProxy() {
     } catch (error) {
       reconnecting = false;
 
-      // Fix 3: Auth error = fatal, não reconectar
-      if (isAuthError(error)) {
-        log('');
-        log('ERRO FATAL: API Key inválida ou revogada.');
-        log('Atualize ZIHIN_API_KEY e reinicie o processo.');
-        process.exit(1);
-      }
+      // Fix 3: auth/versão de protocolo = fatal, não reconectar
+      failIfFatal(error);
 
       log(`Falha ao reconectar: ${error.message}`);
       reconnect(attempt + 1);
@@ -265,7 +283,8 @@ export async function startProxy() {
     try {
       return await operation();
     } catch (error) {
-      if (isAuthError(error)) throw error; // Não retry em auth error
+      // Não retry em erro fatal: reemitir com a mesma key/versão falha igual
+      if (isAuthError(error) || isProtocolVersionError(error)) throw error;
       if (isConnectionError(error)) {
         log(`Erro de conexão detectado. Reconectando...`);
         await reconnect();
@@ -286,6 +305,9 @@ export async function startProxy() {
 
     if (isAuthError(error)) {
       log('Verifique se a API Key é válida e está ativa.');
+    } else if (isProtocolVersionError(error)) {
+      log('O server não aceita mais a versão de protocolo MCP deste proxy.');
+      log('Atualize o pacote: npx @zihin/mcp-server@latest.');
     } else if (error.message.includes('ENOTFOUND') || error.message.includes('ECONNREFUSED')) {
       log('Verifique sua conexão com a internet e a URL do server.');
     }
@@ -381,29 +403,84 @@ export async function startProxy() {
   process.on('SIGTERM', cleanup);
 }
 
-/**
- * Verifica se o erro indica autenticação inválida (401/403).
- * Esses erros são fatais — não faz sentido reconectar com a mesma key.
- */
-function isAuthError(error) {
-  const msg = (error.message || '').toLowerCase();
-  return (
-    msg.includes('401') ||
-    msg.includes('403') ||
-    msg.includes('unauthorized') ||
-    msg.includes('forbidden') ||
-    msg.includes('invalid api key') ||
-    msg.includes('api key')
-  );
+// ─── Classificação de erros ─────────────────────────────────────────
+//
+// Por CÓDIGO primeiro, mensagem só como fallback (espelha o
+// _classifyProbeError do zihin-agent-builder). O código chega em formas
+// diferentes conforme a origem — e a forma MUDA entre SDK v1 e v2, então o
+// classificador já lê as duas para sobreviver à migração da Fase 1:
+//   - SDK v1 StreamableHTTPError: error.code = status HTTP (401, 403, ...)
+//   - SDK v2 SdkHttpError:        error.data.status = status HTTP;
+//                                 error.code = string ('CONNECTION_CLOSED', ...)
+//   - McpError / ProtocolError:   error.code = JSON-RPC numérico (-32xxx)
+//   - Rede (undici):              error.code ou error.cause.code = 'ECONNRESET', ...
+
+/** Código JSON-RPC da spec 2026-07-28 para versão de protocolo não suportada. */
+const UNSUPPORTED_PROTOCOL_VERSION = -32022;
+
+/** Extrai o status HTTP do erro, nas formas do SDK v1 e v2. */
+function httpStatus(error) {
+  const code = error?.code;
+  if (typeof code === 'number' && code >= 100 && code < 600) return code; // v1: StreamableHTTPError
+  const status = error?.data?.status;
+  if (typeof status === 'number') return status; // v2: SdkHttpError
+  return null;
 }
 
 /**
- * Verifica se o erro indica problema de conexão/sessão (recuperável).
+ * Verifica se o erro indica autenticação inválida (401/403).
+ * Esses erros são fatais — não faz sentido reconectar com a mesma key.
+ *
+ * Sem casar 'api key' na mensagem: o texto de erro de uma TOOL remota que
+ * mencione API Key (ex.: config de um tenant) não pode derrubar o processo.
  */
-function isConnectionError(error) {
-  if (isAuthError(error)) return false;
-  const msg = (error.message || '').toLowerCase();
-  const code = error.code || '';
+export function isAuthError(error) {
+  const status = httpStatus(error);
+  if (status === 401 || status === 403) return true;
+  // Fallback para erros que não carregam código (corpo texto de fetch intermediário)
+  const msg = (error?.message || '').toLowerCase();
+  return msg.includes('unauthorized') || msg.includes('forbidden');
+}
+
+/**
+ * Verifica se o server rejeitou a versão do protocolo (-32022, spec
+ * 2026-07-28). Fatal: nenhuma reconexão resolve — só upgrade do pacote.
+ * Forward-looking: o SDK v1 nunca produz esse código; passa a importar
+ * quando o server Zihin desligar o modo legacy.
+ */
+export function isProtocolVersionError(error) {
+  return error?.code === UNSUPPORTED_PROTOCOL_VERSION;
+}
+
+/**
+ * Verifica se o erro indica problema de conexão (recuperável via reconnect).
+ *
+ * Sem as heurísticas 'session'/'404' da era session-based: o server de
+ * produção é stateless (não há mais Mcp-Session-Id para expirar), e um 404
+ * real é endpoint errado — reconectar não conserta.
+ */
+export function isConnectionError(error) {
+  if (isAuthError(error) || isProtocolVersionError(error)) return false;
+
+  const code = error?.code ?? error?.cause?.code; // undici embrulha rede em 'fetch failed' com cause
+  switch (code) {
+    case 'ECONNREFUSED':
+    case 'ENOTFOUND':
+    case 'ECONNRESET':
+    case 'EPIPE':
+    case 'ETIMEDOUT':
+    case 'UND_ERR_CONNECT_TIMEOUT':
+    case 'UND_ERR_SOCKET':
+    case 'CONNECTION_CLOSED': // SDK v2 SdkError
+    case 'SEND_FAILED':       // SDK v2 SdkError
+    case 'REQUEST_TIMEOUT':   // SDK v2 SdkError
+    case -32000:              // JSON-RPC ConnectionClosed
+    case -32001:              // JSON-RPC RequestTimeout
+      return true;
+  }
+
+  // Fallback por mensagem para erros de rede sem código
+  const msg = (error?.message || '').toLowerCase();
   return (
     msg.includes('fetch failed') ||
     msg.includes('econnrefused') ||
@@ -411,13 +488,7 @@ function isConnectionError(error) {
     msg.includes('econnreset') ||
     msg.includes('socket hang up') ||
     msg.includes('network') ||
-    msg.includes('abort') ||
-    msg.includes('session') ||
-    msg.includes('404') ||
-    code === 'ECONNREFUSED' ||
-    code === 'ENOTFOUND' ||
-    code === 'ECONNRESET' ||
-    code === 'UND_ERR_CONNECT_TIMEOUT'
+    msg.includes('abort')
   );
 }
 

--- a/test/error-classification.test.js
+++ b/test/error-classification.test.js
@@ -1,0 +1,104 @@
+/**
+ * Testes da classificação de erros do proxy (Fase 0 da issue #6).
+ *
+ * Sem rede: valida a semântica dos classificadores contra as formas de erro
+ * reais dos dois SDKs — v1 (atual) e v2 (Fase 1) — para que a migração de
+ * SDK não exija reescrever esta lógica.
+ *
+ * Formas cobertas:
+ *   - SDK v1 StreamableHTTPError: error.code = status HTTP numérico
+ *   - SDK v2 SdkHttpError:        error.data.status = status HTTP;
+ *                                 error.code = string ('CONNECTION_CLOSED', ...)
+ *   - McpError / ProtocolError:   error.code = JSON-RPC numérico (-32xxx)
+ *   - Rede (undici):              error.code ou error.cause.code
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isAuthError, isConnectionError, isProtocolVersionError } from '../src/index.js';
+
+/** Erro sintético com propriedades arbitrárias. */
+function err(message, props = {}) {
+  return Object.assign(new Error(message), props);
+}
+
+describe('isAuthError', () => {
+  it('detecta 401/403 pelo code numérico (SDK v1 StreamableHTTPError)', () => {
+    assert.ok(isAuthError(err('Error POSTing to endpoint: {"error":"unauthorized"}', { code: 401 })));
+    assert.ok(isAuthError(err('Forbidden', { code: 403 })));
+  });
+
+  it('detecta 401/403 por data.status (SDK v2 SdkHttpError)', () => {
+    assert.ok(isAuthError(err('HTTP error', { data: { status: 401 } })));
+    assert.ok(isAuthError(err('HTTP error', { data: { status: 403 } })));
+  });
+
+  it('não classifica outros status HTTP como auth', () => {
+    assert.ok(!isAuthError(err('Not found', { code: 404 })));
+    assert.ok(!isAuthError(err('Server error', { code: 500 })));
+    assert.ok(!isAuthError(err('HTTP error', { data: { status: 429 } })));
+  });
+
+  it('fallback por mensagem só para unauthorized/forbidden sem código', () => {
+    assert.ok(isAuthError(err('Request failed: Unauthorized')));
+    assert.ok(isAuthError(err('403 Forbidden at gateway')));
+  });
+
+  it('REGRESSÃO: erro de tool remota mencionando API Key NÃO é auth fatal', () => {
+    // O classificador antigo casava 'api key' na mensagem: um erro de tool
+    // de tenant como este derrubava o proxy inteiro com exit(1).
+    assert.ok(!isAuthError(err('Tool failed: configure a API Key do tenant no painel')));
+    assert.ok(!isAuthError(err('invalid api key format in tool arguments')));
+  });
+});
+
+describe('isProtocolVersionError', () => {
+  it('detecta -32022 (UnsupportedProtocolVersion, spec 2026-07-28)', () => {
+    assert.ok(isProtocolVersionError(err('protocol version not supported', { code: -32022 })));
+  });
+
+  it('não confunde com outros códigos JSON-RPC', () => {
+    assert.ok(!isProtocolVersionError(err('closed', { code: -32000 })));
+    assert.ok(!isProtocolVersionError(err('invalid params', { code: -32602 })));
+    assert.ok(!isProtocolVersionError(err('sem código')));
+  });
+});
+
+describe('isConnectionError', () => {
+  it('detecta erros de rede por code', () => {
+    for (const code of ['ECONNREFUSED', 'ENOTFOUND', 'ECONNRESET', 'ETIMEDOUT', 'UND_ERR_CONNECT_TIMEOUT']) {
+      assert.ok(isConnectionError(err('net fail', { code })), `code ${code}`);
+    }
+  });
+
+  it('detecta code embrulhado em cause (undici fetch failed)', () => {
+    assert.ok(isConnectionError(err('fetch failed', { cause: err('connect', { code: 'ECONNREFUSED' }) })));
+  });
+
+  it('detecta códigos do SDK v2 (strings) e JSON-RPC (números)', () => {
+    for (const code of ['CONNECTION_CLOSED', 'SEND_FAILED', 'REQUEST_TIMEOUT', -32000, -32001]) {
+      assert.ok(isConnectionError(err('conn fail', { code })), `code ${code}`);
+    }
+  });
+
+  it('auth e versão de protocolo NUNCA são erros de conexão (não reconectar)', () => {
+    assert.ok(!isConnectionError(err('unauthorized', { code: 401 })));
+    assert.ok(!isConnectionError(err('forbidden', { data: { status: 403 } })));
+    assert.ok(!isConnectionError(err('unsupported', { code: -32022 })));
+  });
+
+  it('REGRESSÃO: sem heurísticas da era session-based', () => {
+    // Com o server stateless não existe mais sessão para expirar, e um 404
+    // real é endpoint errado — reconectar não conserta nenhum dos dois.
+    assert.ok(!isConnectionError(err('session terminated by server')));
+    assert.ok(!isConnectionError(err('HTTP 404 Not Found')));
+    assert.ok(!isConnectionError(err('Not found', { code: 404 })));
+  });
+
+  it('fallback por mensagem para rede sem código', () => {
+    assert.ok(isConnectionError(err('fetch failed')));
+    assert.ok(isConnectionError(err('socket hang up')));
+    assert.ok(isConnectionError(err('The operation was aborted')));
+  });
+});

--- a/test/error-classification.test.js
+++ b/test/error-classification.test.js
@@ -51,6 +51,19 @@ describe('isAuthError', () => {
     assert.ok(!isAuthError(err('Tool failed: configure a API Key do tenant no painel')));
     assert.ok(!isAuthError(err('invalid api key format in tool arguments')));
   });
+
+  it('sobrevive a erro nulo/vazio/sem message', () => {
+    assert.ok(!isAuthError(null));
+    assert.ok(!isAuthError(undefined));
+    assert.ok(!isAuthError({}));
+  });
+
+  it('code string "401" NÃO classifica (decisão: código é numérico; fallback de mensagem cobre)', () => {
+    // Documenta a decisão: httpStatus() exige número. Um '401' string só
+    // seria auth se a mensagem trouxesse unauthorized/forbidden.
+    assert.ok(!isAuthError(err('erro qualquer', { code: '401' })));
+    assert.ok(!isAuthError(err('erro qualquer', { data: { status: '401' } })));
+  });
 });
 
 describe('isProtocolVersionError', () => {
@@ -88,17 +101,34 @@ describe('isConnectionError', () => {
     assert.ok(!isConnectionError(err('unsupported', { code: -32022 })));
   });
 
-  it('REGRESSÃO: sem heurísticas da era session-based', () => {
-    // Com o server stateless não existe mais sessão para expirar, e um 404
-    // real é endpoint errado — reconectar não conserta nenhum dos dois.
+  it('REGRESSÃO: sem heurísticas de STRING da era session-based', () => {
+    // O que morreu foi o casamento de substring na mensagem ('session',
+    // '404') — induzível por texto arbitrário. Um 404 REAL (código numérico,
+    // vindo do transporte) é transitório de LB/deploy e continua recuperável
+    // — ver teste de status HTTP abaixo.
     assert.ok(!isConnectionError(err('session terminated by server')));
-    assert.ok(!isConnectionError(err('HTTP 404 Not Found')));
-    assert.ok(!isConnectionError(err('Not found', { code: 404 })));
+    assert.ok(!isConnectionError(err('HTTP 404 Not Found'))); // string na msg não basta
   });
 
   it('fallback por mensagem para rede sem código', () => {
     assert.ok(isConnectionError(err('fetch failed')));
     assert.ok(isConnectionError(err('socket hang up')));
     assert.ok(isConnectionError(err('The operation was aborted')));
+  });
+
+  it('status HTTP transitórios de LB/CDN/deploy são recuperáveis', () => {
+    // Substitui de forma principiada o antigo casamento da string '404':
+    // janela de deploy (404), nginx (502), Cloudflare (503), gateway (504).
+    for (const status of [404, 408, 502, 503, 504]) {
+      assert.ok(isConnectionError(err('html do LB', { code: status })), `v1 code ${status}`);
+      assert.ok(isConnectionError(err('html do LB', { data: { status } })), `v2 data.status ${status}`);
+    }
+    // 500 do próprio server não é transitório de infra — propaga ao host.
+    assert.ok(!isConnectionError(err('Internal Server Error', { code: 500 })));
+  });
+
+  it('sobrevive a erro nulo/vazio', () => {
+    assert.ok(!isConnectionError(null));
+    assert.ok(!isConnectionError({}));
   });
 });

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -18,6 +18,12 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const BIN = resolve(__dirname, '..', 'bin', 'zihin-mcp.js');
 const API_KEY = process.env.ZIHIN_API_KEY;
 
+// Dialeto que este teste fala no lado STDIO — o mesmo dos hosts atuais
+// (Claude Desktop/Cursor, handshake clássico). Um knob só: quando o lado
+// stdio ganhar o dialeto 2026-07-28, os testes parametrizam por aqui em vez
+// de caçar strings hardcoded.
+const STDIO_PROTOCOL_VERSION = '2025-03-26';
+
 if (!API_KEY) {
   console.error('ZIHIN_API_KEY não definida — pulando testes de integração.');
   process.exit(0);
@@ -232,7 +238,7 @@ describe('proxy stdio ↔ HTTP', () => {
 
     // MCP exige initialize handshake antes de qualquer request
     const initResult = await request('initialize', {
-      protocolVersion: '2025-03-26',
+      protocolVersion: STDIO_PROTOCOL_VERSION,
       capabilities: {},
       clientInfo: { name: 'test-runner', version: '1.0.0' },
     });
@@ -267,8 +273,11 @@ describe('proxy stdio ↔ HTTP', () => {
       for (const tool of res.result.tools) {
         assert.ok(tool.name, `tool sem name: ${JSON.stringify(tool)}`);
         assert.ok(tool.description, `tool "${tool.name}" sem description`);
+        // Objeto JSON Schema, sem exigir raiz type: 'object' — a spec
+        // 2026-07-28 permite schemas 2020-12 com raiz livre, e o proxy
+        // repassa verbatim o que o server publicar.
         assert.ok(tool.inputSchema, `tool "${tool.name}" sem inputSchema`);
-        assert.equal(tool.inputSchema.type, 'object', `inputSchema de "${tool.name}" deve ser type: object`);
+        assert.equal(typeof tool.inputSchema, 'object', `inputSchema de "${tool.name}" deve ser um objeto JSON Schema`);
       }
     });
 
@@ -484,7 +493,7 @@ describe('proxy stdio ↔ HTTP', () => {
     it('serverInfo deve conter name e version corretos', async () => {
       // Já validado no before(), mas testar novamente com nova request
       const res = await request('initialize', {
-        protocolVersion: '2025-03-26',
+        protocolVersion: STDIO_PROTOCOL_VERSION,
         capabilities: {},
         clientInfo: { name: 'test-protocol', version: '1.0.0' },
       });
@@ -496,7 +505,7 @@ describe('proxy stdio ↔ HTTP', () => {
 
     it('capabilities deve declarar tools, resources e prompts', async () => {
       const res = await request('initialize', {
-        protocolVersion: '2025-03-26',
+        protocolVersion: STDIO_PROTOCOL_VERSION,
         capabilities: {},
         clientInfo: { name: 'test-caps', version: '1.0.0' },
       });

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -25,6 +25,13 @@ const API_KEY = process.env.ZIHIN_API_KEY;
 const STDIO_PROTOCOL_VERSION = '2025-03-26';
 
 if (!API_KEY) {
+  // No CI o skip silencioso é perigoso: secret removido/renomeado deixaria o
+  // workflow verde rodando só os testes offline — exatamente o "verde falso"
+  // que este arquivo existe para impedir. Local, o skip continua válido.
+  if (process.env.CI) {
+    console.error('ZIHIN_API_KEY ausente no CI — os testes de integração são obrigatórios aqui.');
+    process.exit(1);
+  }
   console.error('ZIHIN_API_KEY não definida — pulando testes de integração.');
   process.exit(0);
 }
@@ -154,9 +161,13 @@ function waitForReady(proc) {
   });
 }
 
-/** Anexa o stderr do proxy à mensagem de erro, quando houver. */
+/**
+ * Anexa o stderr do proxy à mensagem de erro, quando houver.
+ * Redige a linha do banner com o sufixo da API Key: este diagnóstico vai
+ * para o log público do GitHub Actions em falha de CI.
+ */
 function formatStderr(stderrBuf) {
-  const trimmed = stderrBuf.trim();
+  const trimmed = stderrBuf.trim().replace(/API Key: \.\.\..+/g, 'API Key: [redigido]');
   return trimmed ? `\n--- stderr do proxy ---\n${trimmed}\n-----------------------` : '';
 }
 
@@ -217,7 +228,14 @@ describe('validação de API Key', () => {
     });
 
     assert.equal(code, 1);
-    assert.ok(stderr.includes('Falha ao conectar') || stderr.includes('ERRO'), 'deve reportar erro de conexão');
+    // Não basta "qualquer falha de boot" (rede offline também sai com ERRO):
+    // esta mensagem só aparece quando isAuthError classificou o 401 real do
+    // server — é o único teste que valida a forma do erro contra produção,
+    // coisa que os unit tests sintéticos não provam.
+    assert.ok(
+      stderr.includes('Verifique se a API Key é válida e está ativa.'),
+      `deve classificar como erro de auth (isAuthError), não como falha genérica. stderr:\n${stderr}`,
+    );
   });
 });
 


### PR DESCRIPTION
Reabertura do #8 — o GitHub fechou aquele PR automaticamente quando a branch base (#7, já mergeado) foi apagada, e PR com base deletada não reabre. Mesma branch, mesmo conteúdo; descrição completa e revisão quádrupla documentadas no #8.

Resumo: Fase 0 da #6 — classificação de erro por código (formas SDK v1 e v2), fim das heurísticas 'api key'/'session'/'404', -32022 fatal com mensagem de upgrade, keepalive com diff por conteúdo, política de não-reemissão para tools/call, consertos de teste (CI guard, assert de auth real, redação de key). 17 unit tests + suíte 45/45 contra produção.

Refs #6, #8

https://claude.ai/code/session_01YBAuDzJzVLEBmfNebydhFD