### PR TITLE
release: v2.0.0 — SDK v2, fases 0 e 1 da compatibilização MCP 2026-07-28

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,18 @@ jobs:
 
       - run: npm ci
 
-      - run: npm publish --access public
+      # Fluxo canary (ago/2026): a publicação real é MANUAL
+      # (npm publish --tag next com passkey; tokens bypass-2FA não publicam
+      # mais desde 28/07/2026). A tag v* é empurrada DEPOIS, como marco +
+      # gate de integração. Se a versão já está no npm, este job vira no-op
+      # verde em vez de falhar com "cannot publish over existing version".
+      - name: Publicar no npm (skip se versão já publicada)
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "@zihin/mcp-server@$VERSION" version >/dev/null 2>&1; then
+            echo "Versão $VERSION já publicada (canary manual) — nada a fazer."
+          else
+            npm publish --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Não lançado
+## 2.0.0 (2026-08-02)
 
 ### Compatibilização MCP 2026-07-28 — Fases 0 e 1 (issue #6)
 
@@ -9,6 +9,18 @@
 - **Keepalive com diff por conteúdo**: com o server stateless (produção desde 01/08) não há GET stream para `list_changed`; o keepalive de 30s é o único detector de mudança e agora compara assinatura, não `length`.
 - **`list_changed` via `ClientOptions.listChanged`**: funciona nas duas eras (notificação legacy hoje, `subscriptions/listen` auto-aberto no dialeto moderno).
 - Testes: falha de boot do proxy vira diagnóstico legível (exit code + stderr) em vez de timeout opaco de 20s; contagens exatas viram pisos; 13 testes unitários novos de classificação de erro; `protocolVersion` dos testes parametrizado em `STDIO_PROTOCOL_VERSION`.
+
+### Revisão quádrupla (segurança/performance/resiliência/cobertura)
+
+- **`tools/call` nunca é reemitido** após erro de conexão/timeout: reemitir `chat_with_agent` não é idempotente e timeout é o caso em que a 1ª execução mais provavelmente ainda roda no server (turno duplicado). O proxy reconecta em background e devolve o erro ao host. `list`/`read`/`get` (idempotentes) mantêm retry transparente.
+- Status HTTP transitórios de LB/CDN/deploy (404/408/502/503/504) são recuperáveis por código, nas formas v1 e v2.
+- Keepalive com `cacheMode: 'bypass'`: nunca servido do cache (auth/queda sempre validados) e sem stamp churn no índice de validators do SDK (evita recompilação AJV no 1º `callTool` após cada tick).
+- Mensagens de erro fatal via `fs.writeSync(2)` — `process.exit()` não drena stderr assíncrono; o host via só "Server disconnected".
+- **Segurança (`install-skills`)**: `name` de skill não pode ser componente de caminho livre — um server comprometido com `name: ../../x` gravava arquivo controlado em diretório arbitrário. Choke point em `parseSkill` (`/^[\w-]+$/`).
+
+### CI/CD
+
+- Testes de integração (que executam um turno real de `chat_with_agent`, com custo de LLM) saem do CI de push/PR — só testes offline lá. A integração real fica como gate do publish (`REQUIRE_INTEGRATION=1`: secret ausente falha em vez de pular).
 
 ## 1.4.0 (2026-07-01)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zihin/mcp-server",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Zihin MCP Server — stdio-to-HTTP proxy para Claude Desktop, Cursor, Claude Code e outros clientes MCP",
   "type": "module",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zihin",
   "description": "Zihin Agent Builder — gerencie agentes de IA da plataforma Zihin direto do Claude Code: MCP server com 96 tools (agentes, schemas, triggers, budget, aprovações, observabilidade) + 6 skills especialistas com os playbooks e gotchas da plataforma.",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "author": {
     "name": "Zihin",
     "url": "https://zihin.ai"

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ import { Server } from '@modelcontextprotocol/server';
 import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
 import { writeSync } from 'node:fs';
 
-const VERSION = '1.4.0';
+const VERSION = '2.0.0';
 const DEFAULT_MCP_URL = 'https://llm.zihin.ai/mcp';
 const VALID_KEY_PREFIXES = ['zhn_live_', 'zhn_test_', 'zhn_dev_'];
 


### PR DESCRIPTION
Bump 2.0.0 (package.json + `VERSION` do proxy + plugin.json), CHANGELOG datado consolidando fases 0/1, revisão quádrupla e mudança de CI/CD, e `publish.yml` adaptado ao fluxo canary (publicação manual `--tag next`; tag v* empurrada depois vira marco + gate, job no-op verde se a versão já está no npm).

**BREAKING**: Node.js >= 20.

Fluxo pós-merge: `npm publish --tag next` manual (passkey) → validação no Claude Desktop com `@zihin/mcp-server@2.0.0` → `npm dist-tag add @zihin/mcp-server@2.0.0 latest` + tag `v2.0.0`.

Prova: `npm pack --dry-run` com os 14 arquivos esperados; suíte 46/46 contra produção.

Refs #6

https://claude.ai/code/session_01YBAuDzJzVLEBmfNebydhFD