### PR TITLE
fix(proxy): espelhar identidade do upstream no handshake stdio (v2.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.1 (2026-08-02)
+
+### Correções
+
+- **Identidade espelhada do upstream no handshake stdio** (achado da validação de canary da 2.0.0 — diff de contrato proxy × servidor, 10/13): o proxy respondia `initialize` com identidade própria (`zihin-mcp-proxy`, sem `title`) e **sem `instructions`** — o texto de 2.110 chars que ensina o modelo a operar as 96 tools (fluxos, RBAC, ponteiro para as skills `zihin://skills/*`). Sem ele, quem instala o pacote opera às cegas: nenhum erro visível, "o agente só erra mais". Agora `serverInfo.name`/`title` e `instructions` são repassados do server real (`client.getServerVersion()`/`getInstructions()`, já obtidos no boot). A `version` continua a do proxy — identifica o hop que responde o stdio em bug reports. Gap pré-existente: a 1.4.0 também nunca repassou (o "pass-through" do CHANGELOG da 1.4.0 nunca valeu para o handshake).
+
 ## 2.0.0 (2026-08-02)
 
 ### Compatibilização MCP 2026-07-28 — Fases 0 e 1 (issue #6)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zihin/mcp-server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Zihin MCP Server — stdio-to-HTTP proxy para Claude Desktop, Cursor, Claude Code e outros clientes MCP",
   "type": "module",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zihin",
   "description": "Zihin Agent Builder — gerencie agentes de IA da plataforma Zihin direto do Claude Code: MCP server com 96 tools (agentes, schemas, triggers, budget, aprovações, observabilidade) + 6 skills especialistas com os playbooks e gotchas da plataforma.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": {
     "name": "Zihin",
     "url": "https://zihin.ai"

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ import { Server } from '@modelcontextprotocol/server';
 import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
 import { writeSync } from 'node:fs';
 
-const VERSION = '2.0.0';
+const VERSION = '2.0.1';
 const DEFAULT_MCP_URL = 'https://llm.zihin.ai/mcp';
 const VALID_KEY_PREFIXES = ['zhn_live_', 'zhn_test_', 'zhn_dev_'];
 
@@ -338,9 +338,21 @@ export async function startProxy() {
   if (remoteResources.length > 0) capabilities.resources = {};
   if (remotePrompts.length > 0) capabilities.prompts = {};
 
+  // Identidade ESPELHADA do upstream (achado da validação de canary 2.0.0):
+  // name/title/instructions vêm do server real — o proxy é transparente, e o
+  // instructions é o texto que ensina o modelo a operar as 96 tools (fluxos,
+  // RBAC, ponteiro para as skills zihin://skills/*). Sem repassá-lo, quem
+  // instala o pacote opera às cegas e "o agente só erra mais", sem erro
+  // visível. A version continua a do PROXY: identifica o hop que responde o
+  // stdio (essencial em bug report); a do server aparece via whoami/banner.
+  const upstreamInfo = remoteClient.getServerVersion() || {};
   const localServer = new Server(
-    { name: 'zihin-mcp-proxy', version: VERSION },
-    { capabilities },
+    {
+      name: upstreamInfo.name || 'zihin-mcp-proxy',
+      ...(upstreamInfo.title ? { title: upstreamInfo.title } : {}),
+      version: VERSION,
+    },
+    { capabilities, instructions: remoteClient.getInstructions() },
   );
 
   // Handlers registrados pela STRING do método (SDK v2) — o handler continua

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -265,7 +265,7 @@ describe('proxy stdio ↔ HTTP', () => {
 
     assert.ok(initResult.result, 'initialize deve retornar result');
     assert.ok(initResult.result.serverInfo, 'deve ter serverInfo');
-    assert.equal(initResult.result.serverInfo.name, 'zihin-mcp-proxy');
+    assert.equal(initResult.result.serverInfo.name, 'zihin-builder', 'identidade espelhada do upstream');
 
     // Enviar initialized notification (sem id)
     proc.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
@@ -510,8 +510,10 @@ describe('proxy stdio ↔ HTTP', () => {
   // ── MCP Protocol ──
 
   describe('protocolo MCP', () => {
-    it('serverInfo deve conter name e version corretos', async () => {
-      // Já validado no before(), mas testar novamente com nova request
+    it('serverInfo espelha a identidade do upstream; version é a do proxy', async () => {
+      // Identidade espelhada (fix da validação de canary 2.0.0): o host vê o
+      // PRODUTO (zihin-builder), não o hop. A version é a do proxy — é ela
+      // que identifica o binário que responde o stdio num bug report.
       const res = await request('initialize', {
         protocolVersion: STDIO_PROTOCOL_VERSION,
         capabilities: {},
@@ -519,8 +521,24 @@ describe('proxy stdio ↔ HTTP', () => {
       });
 
       const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
-      assert.equal(res.result.serverInfo.name, 'zihin-mcp-proxy');
-      assert.equal(res.result.serverInfo.version, pkg.version);
+      assert.equal(res.result.serverInfo.name, 'zihin-builder', 'name espelhado do server');
+      assert.ok(res.result.serverInfo.title, 'title espelhado do server');
+      assert.equal(res.result.serverInfo.version, pkg.version, 'version é a do proxy');
+    });
+
+    it('instructions do server chegam ao host local (ponteiro para as skills)', async () => {
+      // O instructions ensina o modelo a operar as 96 tools e aponta para as
+      // skills zihin://skills/*. Sem repassá-lo, o pacote opera às cegas —
+      // o usuário não vê erro, só "o agente erra mais".
+      const res = await request('initialize', {
+        protocolVersion: STDIO_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: 'test-instructions', version: '1.0.0' },
+      });
+
+      const instructions = res.result.instructions;
+      assert.equal(typeof instructions, 'string', 'instructions deve ser string');
+      assert.ok(instructions.length > 100, `instructions substancial (recebeu ${instructions?.length ?? 0} chars)`);
     });
 
     it('capabilities deve declarar tools, resources e prompts', async () => {


### PR DESCRIPTION
## O que é

Fix dos 3 checks de identidade reprovados na validação de canary da 2.0.0 (diff de contrato proxy × servidor, 10/13):

| Item | Antes | Agora |
|---|---|---|
| `instructions` | 0 chars | 2.110 chars do server (fluxos, RBAC, ponteiro para `zihin://skills/*`) |
| `serverInfo.name` | `zihin-mcp-proxy` | `zihin-builder` (espelhado) |
| `serverInfo.title` | `undefined` | `"Zihin Agent Builder"` (espelhado) |

`client.getServerVersion()`/`getInstructions()` — o client conecta antes de o server local nascer, o dado já está na mão. **`version` continua a do proxy** (decisão): é ela que identifica o hop que responde o stdio num bug report; a do server aparece via whoami/banner.

Nota: gap **pré-existente** — a 1.4.0 também nunca repassou; não é regressão da 2.0.0.

## Prova

47/47 contra produção, incluindo 2 testes novos: espelhamento de name/title + instructions substancial no `initialize`.

Pós-merge: publicar `2.0.1 --tag next` (manual, passkey) → revalidação do canary → promoção a `latest` + tag.

https://claude.ai/code/session_01YBAuDzJzVLEBmfNebydhFD