### PR TITLE
docs: revisão final pré-promoção da v2.0.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,8 @@ Pacote npm `@zihin/mcp-server` — proxy stdio-to-HTTP que conecta clientes MCP 
 Cliente MCP <-stdio-> [Proxy local (src/index.js)] <-HTTP-> https://llm.zihin.ai/mcp
 ```
 
-- `src/index.js` — proxy principal (~140 LOC), exporta `startProxy()`
+- `src/index.js` — proxy principal (~560 linhas), exporta `startProxy()` e os classificadores de erro (`isAuthError`/`isConnectionError`/`isProtocolVersionError`)
+- `src/install-skills.js` — subcomando `install-skills` (skills no formato nativo de cada client)
 - `bin/zihin-mcp.js` — CLI entry point
 - Usa MCP SDK v2: `Client` + `StreamableHTTPClientTransport` (`@modelcontextprotocol/client`) e `Server` low-level + `StdioServerTransport` (`@modelcontextprotocol/server`)
 - Auth via header `X-Api-Key`, RBAC enforced server-side
@@ -28,7 +29,7 @@ ZIHIN_API_KEY=zhn_live_xxx node bin/zihin-mcp.js
 ## Convencoes
 
 - Idioma: portugues brasileiro para docs, commits e comentarios
-- Formato de commit: `feat(scope): descricao` com `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+- Formato de commit: `feat(scope): descricao` com `Co-Authored-By: Claude <modelo> <noreply@anthropic.com>`
 - Sem emojis
 - JS puro, ESM (`type: module`), Node.js >= 20 (exigido pelo SDK v2)
 - Zero devDependencies — testes usam `node:test` nativo
@@ -41,10 +42,14 @@ zihin-mcp/
 ├── package.json
 ├── bin/zihin-mcp.js       <- CLI entry point
 ├── src/index.js           <- Proxy stdio-to-HTTP
-├── test/proxy.test.js     <- 19 testes de integracao
+├── src/install-skills.js  <- Subcomando install-skills
+├── test/proxy.test.js     <- Integracao real contra producao (requer key)
+├── test/error-classification.test.js  <- Unit, sem rede
+├── test/install-skills.test.js        <- Unit + e2e local, sem rede
+├── plugin/                <- Plugin Claude Code (skills empacotadas)
 ├── .github/workflows/
-│   ├── ci.yml             <- Testes em push/PR
-│   └── publish.yml        <- Testes + npm publish em tag v*
+│   ├── ci.yml             <- Testes OFFLINE em push/PR (sem key — nao queima turno de agente)
+│   └── publish.yml        <- Gate de integracao real (REQUIRE_INTEGRATION=1) em tag v*; publish e no-op se a versao ja esta no npm
 ├── README.md
 ├── CHANGELOG.md
 ├── LICENSE (MIT)
@@ -59,18 +64,26 @@ zihin-mcp/
 
 ## Testes
 
-19 testes de integracao real contra producao (nada mockado):
-- Validacao de API Key (sem key, prefixo invalido, key invalida)
+47 testes — unitarios offline + integracao real contra producao (nada mockado):
+- Unit (sem rede): classificadores de erro (formas SDK v1 e v2, regressoes nomeadas), conversores do install-skills, path traversal
+- Validacao de API Key (sem key, prefixo invalido, key invalida — exige a mensagem de classificacao de auth)
 - Tools: list, call, chat_with_agent (sessao + continuidade), tool inexistente
-- Resources: list, read (3 URIs: models, agents, schema-templates)
-- Prompts: list, get com argumentos
-- Protocolo MCP: serverInfo, capabilities
+- Resources: list (pisos + invariante de categoria, nao contagem exata), read
+- Prompts: list (presenca dos conhecidos), get com argumentos
+- Protocolo MCP: identidade espelhada do upstream (serverInfo.name/title), instructions repassado, capabilities
+
+ATENCAO: a suite de integracao executa um turno REAL de chat_with_agent (custo de LLM no tenant). Sem ZIHIN_API_KEY os testes de integracao pulam (skip local); com REQUIRE_INTEGRATION=1, key ausente = falha (gate de publish).
 
 ## CI/CD
 
-GitHub Secrets necessarios:
-- `NPM_TOKEN` — token npm para publicar `@zihin/mcp-server`
-- `ZIHIN_API_KEY` — key para rodar testes de integracao no CI
+GitHub Secrets:
+- `ZIHIN_API_KEY` — key para o gate de integracao (SO no publish.yml; o ci.yml de push/PR roda offline)
+- `NPM_TOKEN` — legado; tokens bypass-2FA nao publicam desde 28/07/2026
+
+Publicacao (fluxo canary, decidido em 02/08/2026):
+1. `npm publish --tag next` MANUAL (passkey; npm abre o navegador — nao pedir --otp)
+2. Validacao do canary (diff de contrato proxy x servidor + client real)
+3. `npm dist-tag add @zihin/mcp-server@X.Y.Z latest` + push da tag `vX.Y.Z` (o publish.yml detecta versao ja publicada e vira no-op verde)
 
 ## Nao commitar
 

--- a/README.md
+++ b/README.md
@@ -180,8 +180,8 @@ As capabilities disponiveis dependem do role da API Key, controlado server-side:
 
 | Role | Tools | Resources | Prompts |
 |------|-------|-----------|---------|
-| `admin` | Todas (96) | 19 | 3 |
-| `editor` | Leitura (52 — writes nao sao listadas) | 19 | 3 |
+| `admin` | Todas (96) | 20 | 3 |
+| `editor` | Leitura (52 — writes nao sao listadas) | 20 | 3 |
 | `member` | Subset consumer (5) | - | - |
 
 O numero exato de tools pode variar conforme o server evolui.
@@ -193,7 +193,7 @@ O numero exato de tools pode variar conforme o server evolui.
 | `zihin://agents` | Lista de agentes do tenant |
 | `zihin://models` | Catalogo de modelos LLM disponiveis |
 | `zihin://schema-templates` | Templates de schema para configuracao |
-| `zihin://schemas/{tipo}` | Contrato formal (JSON Schema) de cada payload — o mesmo que o server valida (10 tipos) |
+| `zihin://schemas/{tipo}` | Contrato formal (JSON Schema) de cada payload — o mesmo que o server valida (11 tipos) |
 | `zihin://skills/{slug}` | Playbooks procedurais (6 skills — ver secao Skills acima) |
 
 ### Prompts disponiveis
@@ -206,13 +206,15 @@ O numero exato de tools pode variar conforme o server evolui.
 
 ## Testes
 
-O projeto inclui 19 testes de integracao real contra o server de producao:
+47 testes: unitarios offline (classificacao de erros, install-skills) + integracao real contra o server de producao. Sem `ZIHIN_API_KEY`, so os offline rodam; com a key, a suite completa:
 
 ```bash
 ZIHIN_API_KEY=zhn_live_xxx npm test
 ```
 
-Cobertura: validacao de API Key, tools (incluindo `chat_with_agent` com session tracking), resources, prompts e protocolo MCP.
+Cobertura: validacao de API Key, tools (incluindo `chat_with_agent` com session tracking e continuidade), resources, prompts, protocolo MCP (identidade espelhada + instructions) e classificacao de erros (formas SDK v1 e v2).
+
+> A suite de integracao executa um turno REAL de agente (custo de LLM no tenant). No CI ela roda apenas no gate de publish.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Contagens reais de produção no README (20 resources/11 schemas/47 testes), CLAUDE.md alinhado à estrutura e ao fluxo de CI/CD atual (offline em push/PR, gate de integração no publish, fluxo canary documentado). Sem mudança de código.

https://claude.ai/code/session_01YBAuDzJzVLEBmfNebydhFD