### PR TITLE
feat(proxy): liga o dialeto 2026-07-28 no lado HTTP — Fase 2 da issue #6 (v2.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.1.0 (2026-08-02)
+
+### Compatibilização MCP 2026-07-28 — Fase 2 (issue #6): dialeto moderno ligado
+
+- **Flip do dialeto no lado HTTP**: `versionNegotiation: { mode: 'auto' }` no client. O `connect()` agora faz o probe `server/discover`; contra o server de produção (v2.4.0, spec 2026-07-28) a conexão negocia a era moderna — os requests do proxy saem de `era=legacy` na métrica do server. O fallback é automático e conservador: qualquer resposta que não seja evidência moderna definitiva (server antigo, rollback) cai no handshake `initialize` byte-idêntico ao da 2.0.x. O lado stdio permanece no dialeto clássico — o proxy é o tradutor.
+- **`resultType` defensivo**: `inputRequired: { autoFulfill: false }`. O proxy não tem UI nem registra handlers de elicitation/sampling/roots; sem o modo manual, um `input_required` (vocabulário novo da era moderna) entraria no driver de auto-fulfilment do SDK contra handlers inexistentes. Agora vira erro imediato, convertido em mensagem clara ao host no `tools/call` (novo classificador exportado `isInputRequiredError`). Rede de segurança: o proxy não declara as capabilities que autorizariam o server a pedir input.
+- **`reconnectionOptions` removido do transport**: resumability de SSE só existe para o GET stream, que o server stateless não oferece — era código morto. A reconexão real continua sendo a do proxy (`reconnect()`, backoff exponencial próprio).
+
 ## 2.0.1 (2026-08-02)
 
 ### Correções

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zihin/mcp-server",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Zihin MCP Server — stdio-to-HTTP proxy para Claude Desktop, Cursor, Claude Code e outros clientes MCP",
   "type": "module",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zihin",
   "description": "Zihin Agent Builder — gerencie agentes de IA da plataforma Zihin direto do Claude Code: MCP server com 96 tools (agentes, schemas, triggers, budget, aprovações, observabilidade) + 6 skills especialistas com os playbooks e gotchas da plataforma.",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "author": {
     "name": "Zihin",
     "url": "https://zihin.ai"

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ import { Server } from '@modelcontextprotocol/server';
 import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
 import { writeSync } from 'node:fs';
 
-const VERSION = '2.0.1';
+const VERSION = '2.1.0';
 const DEFAULT_MCP_URL = 'https://llm.zihin.ai/mcp';
 const VALID_KEY_PREFIXES = ['zhn_live_', 'zhn_test_', 'zhn_dev_'];
 
@@ -75,11 +75,20 @@ export async function startProxy() {
   const remoteClient = new Client(
     { name: 'zihin-mcp-proxy', version: VERSION },
     {
-      // versionNegotiation ausente = modo 'legacy': handshake initialize
-      // byte-idêntico ao SDK v1 (invariante da Fase 1: sem mudança de
-      // comportamento observável). A Fase 2 liga o dialeto 2026-07-28
-      // trocando para { mode: 'auto' } — probe server/discover com fallback
-      // automático para initialize.
+      // Fase 2: dialeto 2026-07-28 ligado. O connect() faz o probe
+      // server/discover; evidência moderna definitiva liga a era nova, e
+      // QUALQUER outra resposta (server antigo, rollback de deploy) cai no
+      // initialize legacy byte-idêntico ao de antes — o flip é seguro nos
+      // dois sentidos. Queda de rede continua rejeitando com erro tipado
+      // (em HTTP, silêncio é outage, não sinal de era).
+      versionNegotiation: { mode: 'auto' },
+      // O proxy não tem UI: nenhum handler de elicitation/sampling/roots
+      // registrado. Sem isto, um input_required (vocabulário novo da era
+      // moderna) entraria no driver de auto-fulfilment do SDK, que despacha
+      // para handlers inexistentes. Em modo manual ele vira SdkError
+      // UNSUPPORTED_RESULT_TYPE imediato — convertido em mensagem clara ao
+      // host no handler de tools/call (ver isInputRequiredError).
+      inputRequired: { autoFulfill: false },
       //
       // listChanged substitui os três setNotificationHandler do SDK v1.
       // Funciona nas duas eras: notificação legacy (GET stream) hoje,
@@ -117,14 +126,11 @@ export async function startProxy() {
     const httpTransport = new StreamableHTTPClientTransport(
       new URL(mcpUrl),
       {
+        // Sem reconnectionOptions: resumability de SSE só existe para o GET
+        // stream, e o server stateless (v2.4.0) não o oferece — a reconexão
+        // real é a do proxy (reconnect(), backoff próprio).
         requestInit: {
           headers: { 'X-Api-Key': apiKey },
-        },
-        reconnectionOptions: {
-          maxReconnectionDelay: RECONNECT_MAX_MS,
-          initialReconnectionDelay: RECONNECT_BASE_MS,
-          reconnectionDelayGrowFactor: 2,
-          maxRetries: 5,
         },
       },
     );
@@ -369,8 +375,12 @@ export async function startProxy() {
     try {
       return await withRetry(() => remoteClient.callTool({ name, arguments: args }), { reissue: false });
     } catch (error) {
+      const text = isInputRequiredError(error)
+        ? `A tool "${name}" pediu input interativo (input_required) e o proxy não tem interface para responder. ` +
+          'Reenvie a chamada com todos os argumentos necessários preenchidos.'
+        : `Erro ao executar tool "${name}": ${error.message}`;
       return {
-        content: [{ type: 'text', text: `Erro ao executar tool "${name}": ${error.message}` }],
+        content: [{ type: 'text', text }],
         isError: true,
       };
     }
@@ -481,6 +491,19 @@ export function isAuthError(error) {
  */
 export function isProtocolVersionError(error) {
   return error?.code === UNSUPPORTED_PROTOCOL_VERSION;
+}
+
+/**
+ * Verifica se o erro é um input_required do dialeto 2026-07-28 em modo manual
+ * (inputRequired.autoFulfill: false): o SDK v2 devolve SdkError com code
+ * 'UNSUPPORTED_RESULT_TYPE' e data.resultType = 'input_required'. Não é erro
+ * de conexão (reconectar não muda nada) nem fatal — o handler de tools/call
+ * converte em mensagem clara ao host. Na prática não deve ocorrer: o proxy
+ * não declara capabilities de elicitation/sampling/roots, então o server não
+ * tem base para pedir input; isto é a rede de segurança.
+ */
+export function isInputRequiredError(error) {
+  return error?.code === 'UNSUPPORTED_RESULT_TYPE' && error?.data?.resultType === 'input_required';
 }
 
 /**

--- a/test/error-classification.test.js
+++ b/test/error-classification.test.js
@@ -16,7 +16,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { isAuthError, isConnectionError, isProtocolVersionError } from '../src/index.js';
+import { isAuthError, isConnectionError, isInputRequiredError, isProtocolVersionError } from '../src/index.js';
 
 /** Erro sintético com propriedades arbitrárias. */
 function err(message, props = {}) {
@@ -75,6 +75,39 @@ describe('isProtocolVersionError', () => {
     assert.ok(!isProtocolVersionError(err('closed', { code: -32000 })));
     assert.ok(!isProtocolVersionError(err('invalid params', { code: -32602 })));
     assert.ok(!isProtocolVersionError(err('sem código')));
+  });
+});
+
+describe('isInputRequiredError', () => {
+  // Forma real do SDK v2 em modo manual (inputRequired.autoFulfill: false):
+  // SdkError UNSUPPORTED_RESULT_TYPE com data = { resultType, method }.
+  const inputRequired = () =>
+    err("Unsupported result type 'input_required' for tools/call", {
+      code: 'UNSUPPORTED_RESULT_TYPE',
+      data: { resultType: 'input_required', method: 'tools/call' },
+    });
+
+  it('detecta o input_required do modo manual (dialeto 2026-07-28)', () => {
+    assert.ok(isInputRequiredError(inputRequired()));
+  });
+
+  it('outros resultType desconhecidos NÃO classificam (mensagem genérica do SDK basta)', () => {
+    assert.ok(!isInputRequiredError(err("Unsupported result type 'algo_novo' for tools/call", {
+      code: 'UNSUPPORTED_RESULT_TYPE',
+      data: { resultType: 'algo_novo', method: 'tools/call' },
+    })));
+  });
+
+  it('não confunde com erros de conexão nem com code solto', () => {
+    assert.ok(!isInputRequiredError(err('closed', { code: 'CONNECTION_CLOSED' })));
+    assert.ok(!isInputRequiredError(err('sem data', { code: 'UNSUPPORTED_RESULT_TYPE' })));
+    assert.ok(!isInputRequiredError(null));
+  });
+
+  it('input_required NÃO é erro de conexão nem fatal (não reconecta, não derruba)', () => {
+    assert.ok(!isConnectionError(inputRequired()));
+    assert.ok(!isAuthError(inputRequired()));
+    assert.ok(!isProtocolVersionError(inputRequired()));
   });
 });
 


### PR DESCRIPTION
Fecha a Fase 2 da #6 — o proxy passa a falar o dialeto MCP 2026-07-28 com o server de produção. Release alvo: **2.1.0** pelo fluxo canary (`--tag next` manual → validação → promote).

## O que muda

**1. Flip do dialeto** (`versionNegotiation: { mode: 'auto' }`)
O `connect()` agora faz o probe `server/discover`. Contra o server v2.4.0 (spec 2026-07-28, stateless), a conexão negocia a era moderna — é o que tira os usuários do proxy de `era=legacy` na métrica do server, a razão de negócio da migração inteira. O fallback do SDK é conservador: qualquer resposta que não seja evidência moderna definitiva (server antigo, rollback de deploy) cai no handshake `initialize` byte-idêntico ao da 2.0.x; queda de rede rejeita com erro tipado (em HTTP, silêncio é outage, não sinal de era). O lado stdio permanece no dialeto clássico — o proxy segue tradutor.

**2. `resultType` defensivo** (`inputRequired: { autoFulfill: false }`)
Verificado no SDK 2.0.0: com auto-fulfilment (default), um `input_required` entraria no driver multi-round-trip despachando para handlers de elicitation/sampling/roots que o proxy não registra. Em modo manual vira `SdkError UNSUPPORTED_RESULT_TYPE` (`data.resultType = 'input_required'`) imediato — o `tools/call` converte em mensagem clara ao host via o novo `isInputRequiredError` (exportado, coberto por unit tests). Rede de segurança: o proxy não declara as capabilities que autorizariam o server a pedir input.

**3. `reconnectionOptions` removido do transport**
Resumability SSE só existe para o GET stream, que o server stateless não oferece — código morto. A reconexão real continua sendo a do proxy (`reconnect()`, backoff exponencial próprio, MAX 10 tentativas).

## Testes

- 32 testes offline verdes (5 novos: classificação de `input_required`, incluindo a regressão "não é erro de conexão nem fatal")
- Integração real fica para o gate do canary — a validação decisiva do flip é do lado do server: os requests do proxy aparecerem como `era=modern` na métrica, mais o diff de contrato proxy × servidor no `next`

## Fora de escopo (ficam na #6)

Fase 3: extensão Tasks para `chat_with_agent` (turnos >60s hoje morrem com timeout) e pass-through de `traceparent`.

https://claude.ai/code/session_01YBAuDzJzVLEBmfNebydhFD
